### PR TITLE
Update ImguiConsole.h

### DIFF
--- a/Source/BYGImguiLogger/Public/ImguiConsole.h
+++ b/Source/BYGImguiLogger/Public/ImguiConsole.h
@@ -379,7 +379,7 @@ struct FBYGAppConsole
 			Strtrim(s);
 			if (s[0])
 				ExecCommand(s);
-			strcpy(s, "");
+			strcpy_s(s, sizeof s, "");
 			reclaim_focus = true;
 		}
 


### PR DESCRIPTION
Fix compile warning about `strcpy` been deprecated.
